### PR TITLE
fixed SAT collision detection bug

### DIFF
--- a/Sharpex2D/Math/Polygon.cs
+++ b/Sharpex2D/Math/Polygon.cs
@@ -121,7 +121,7 @@ namespace Sharpex2D.Math
                 Vector2 edge = Points[i] - Points[prev];
 
                 var v = new Vector2(edge.X, edge.Y);
-                v.CrossProduct();
+                v = v.CrossProduct();
                 v.Normalize();
 
                 float aMin, aMax, bMin, bMax;
@@ -130,6 +130,7 @@ namespace Sharpex2D.Math
 
                 if ((aMax < bMin) || (bMax < aMin))
                     return true;
+
 
                 float overlapping = aMax < bMax ? aMax - bMin : bMax - aMin;
                 if (overlapping < minOverlap)


### PR DESCRIPTION
v.CrossProduct() was used as self-modifying void, but returns a new Vector2
